### PR TITLE
Migrate desktop wiki to docs

### DIFF
--- a/docs/build_desktop.md
+++ b/docs/build_desktop.md
@@ -1,0 +1,47 @@
+---
+id: build_desktop
+title: Build Desktop
+---
+
+## Prerequisites:
+lein, node.js v.8 , cmake, cmake-extra-modules, Qt 5.9.1, Qt's qmake available in PATH
+
+cmake-extra-modules can be installed by running:
+```
+Linux:
+sudo apt install extra-cmake-modules
+
+MacOS:
+brew install kde-mac/kde/kf5-extra-cmake-modules
+```
+
+Note: add qmake to PATH via:
+```
+Linux:
+export PATH=<QT_PATH>/gcc_64/bin:$PATH
+
+MacOS:
+export PATH=<QT_PATH>/clang_64/bin:$PATH
+```
+
+Caveats:
+  - if npm hangs at some step, check the version. If it's 5.6.0, try downgrading to 5.5.1 via `npm install -g npm@5.5.1`
+
+# To install react-native-cli with desktop commands support:
+1. git clone https://github.com/status-im/react-native-desktop.git
+2. cd react-native-desktop/react-native-cli
+3. npm update
+4. npm install -g
+
+# To setup re-natal dev builds of status-react for Desktop:
+1. git clone https://github.com/status-im/status-react.git
+2. cd status-react
+3. scripts/prepare-for-platform.sh desktop
+4. npm install
+5. lein deps
+6. ./re-natal use-figwheel (run `ln -s node_modules/re-natal/index.js re-natal` if you don't have `re-natal`)
+7. ./re-natal enable-source-maps
+8. In separate terminal tab: `npm start` (note: it starts react-native packager )
+9. In separate terminal tab: node ./ubuntu-server.js
+10. In separate terminal tab: lein figwheel-repl desktop (note: wait until sources compiled)
+11. In separate terminal tab: react-native run-desktop

--- a/docs/build_desktop.md
+++ b/docs/build_desktop.md
@@ -3,45 +3,85 @@ id: build_desktop
 title: Build Desktop
 ---
 
-## Prerequisites:
-lein, node.js v.8 , cmake, cmake-extra-modules, Qt 5.9.1, Qt's qmake available in PATH
+# Development environment setup
 
-cmake-extra-modules can be installed by running:
-```
-Linux:
-sudo apt install extra-cmake-modules
+## Prerequisites
 
-MacOS:
-brew install kde-mac/kde/kf5-extra-cmake-modules
-```
+lein, node.js v.8, cmake, Qt 5.9.1 (with QtWebEngine components installed), Qt's qmake available in PATH. If building on Ubuntu newer than 16.10, then Qt 5.10.1 is recommended (although not fully tested).
 
-Note: add qmake to PATH via:
-```
-Linux:
-export PATH=<QT_PATH>/gcc_64/bin:$PATH
+Note: add qmake to PATH via
 
-MacOS:
-export PATH=<QT_PATH>/clang_64/bin:$PATH
-```
+- On MacOS: `export PATH=<QT_PATH>/clang_64/bin:$PATH`
+- On Linux: `export PATH=<QT_PATH>/gcc_64/bin:$PATH`
 
 Caveats:
-  - if npm hangs at some step, check the version. If it's 5.6.0, try downgrading to 5.5.1 via `npm install -g npm@5.5.1`
 
-# To install react-native-cli with desktop commands support:
-1. git clone https://github.com/status-im/react-native-desktop.git
-2. cd react-native-desktop/react-native-cli
-3. npm update
-4. npm install -g
+- If npm hangs at some step, check the version. If it's 5.6.0 or higher, try downgrading to 5.5.1 via `npm install -g npm@5.5.1`
 
-# To setup re-natal dev builds of status-react for Desktop:
-1. git clone https://github.com/status-im/status-react.git
-2. cd status-react
-3. scripts/prepare-for-platform.sh desktop
-4. npm install
-5. lein deps
-6. ./re-natal use-figwheel (run `ln -s node_modules/re-natal/index.js re-natal` if you don't have `re-natal`)
-7. ./re-natal enable-source-maps
-8. In separate terminal tab: `npm start` (note: it starts react-native packager )
-9. In separate terminal tab: node ./ubuntu-server.js
-10. In separate terminal tab: lein figwheel-repl desktop (note: wait until sources compiled)
-11. In separate terminal tab: react-native run-desktop
+## To install react-native-cli with desktop commands support
+
+``` bash
+git clone https://github.com/status-im/react-native-desktop.git
+cd react-native-desktop/react-native-cli
+npm update
+npm install -g
+```
+
+## To setup re-natal dev builds of status-react for Desktop
+
+1. Run the following commands:
+    ``` bash
+    git clone https://github.com/status-im/status-react.git
+    cd status-react
+    scripts/prepare-for-platform.sh desktop
+    npm install
+    ln -sf './node_modules/re-natal/index.js' './re-natal'
+    ./re-natal use-figwheel
+    ./re-natal enable-source-maps
+    ```
+1. In separate terminal tab: `npm start` (note: it starts react-native packager )
+1. In separate terminal tab: `node ./ubuntu-server.js`
+1. In separate terminal tab: `lein figwheel-repl desktop` (note: wait until sources are compiled)
+1. In separate terminal tab: `react-native run-desktop`
+
+## Editor setup
+
+Running `lein figwheel-repl desktop` will run a REPL on port 7888 by default. Some additional steps might be needed to connect to it.
+
+### emacs-cider
+
+In order to get REPL working, use the below elisp code:
+
+``` clojure
+(defun custom-cider-jack-in ()
+  (interactive)
+  (let ((status-desktop-params "with-profile +figwheel repl"))
+    (set-variable 'cider-lein-parameters status-desktop-params)
+    (message "setting 'cider-lein-parameters")
+    (cider-jack-in)))
+
+(defun start-figwheel-cljs-repl ()
+  (interactive)
+  (set-buffer "*cider-repl status-react*")
+  (goto-char (point-max))
+  (insert "(do (use 'figwheel-api)
+           (start [:desktop])
+           (start-cljs-repl))")
+  (cider-repl-return))
+```
+
+`custom-cider-jack-in` sets the correct profile for leiningen, and can be run as soon as emacs is open.
+run `start-figwheel-cljs-repl` once you already have a cider repl session from the jack-in
+
+### vim-fireplace
+
+For some reason there is no `.nrepl-port` file in project root, so `vim-fireplace` will not be able to connect automatically. You can either:
+
+- run `:Connect` and answer a couple of interactive prompts
+- create `.nrepl-port` file manually and add a single line containing `7888` (or whatever port REPL is running on)
+
+After Figwheel has connected to the app, run the following command inside Vim, and you should be all set:
+
+``` clojure
+:Piggieback (figwheel-sidecar.repl-api/repl-env)
+```

--- a/docs/build_desktop_google_breakpad.md
+++ b/docs/build_desktop_google_breakpad.md
@@ -1,0 +1,34 @@
+---
+id: build_desktop_google_breakpad
+title: Google Breakpad integration
+---
+
+## Overview
+
+Since Google's Breakpad library requires `depot` tools to checkout sources from source control and build dedicated tools used to analyze generated `minidumps` files, repackaged version with pure breakpad library source code to be compiled along with application sources was added into [repo](https://github.com/status-im/google-breakpad).
+
+[google-breakpad repo](https://github.com/status-im/google-breakpad) also contains CMake files for easy integration with applications based on react-native-desktop.
+
+After crash occurs and intercepted by breakpad it creates `minidump` file with useful crash related information. Extracting human readable information from minidump file format requires running of `minidump_stackwalk` tool with specially pre-generated symbol files on application binaries.
+
+### Getting readable stack trace from user submitted files
+
+1. Original breakpad repository should be checked out on dev machine and built locally. ( https://github.com/google/breakpad#getting-started-from-master )
+
+2. Use `dump_syms` tool to generate symbols file from StatusIm binary file submitted by user:
+
+`$google-breakpad/src/tools/linux/dump_syms/dump_syms ./StatusIm > StatusIm.sym`  
+`$head -n1 StatusIm.sym`
+
+Above command output may looks something like:
+
+`MODULE Linux x86_64 6EDC6ACDB282125843FD59DA9C81BD830 StatusIm`
+
+To structure symbols file correctly you can do following next:
+
+`$mkdir -p ./symbols/StatusIm/6EDC6ACDB282125843FD59DA9C81BD830`  
+`$mv StatusIm.sym ./symbols/StatusIm/6EDC6ACDB282125843FD59DA9C81BD830`
+
+3. Generate readable stack trace pointing to the place with crash by running `minidump_stackwalk` tool on minidump file submitted by user with passing the path to previously generated symbol files:
+
+`$google-breakpad/src/processor/minidump_stackwalk 09fd98ec-d55c-29e1-4ae067b0-4aaec0d6.dmp ./symbols`

--- a/docs/build_desktop_jenkins.md
+++ b/docs/build_desktop_jenkins.md
@@ -1,0 +1,35 @@
+---
+id: build_desktop_jenkins
+title: Jenkins Setup for Desktop
+---
+
+## Mac OS
+
+Qt 5.9.1 can be installed from brew receipt:
+
+```
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/a505729a8c75aa9e83f31fdcac0223746a88e8e9/Formula/qt.rb
+brew link qt --force
+ln -s /usr/local/Cellar/qt/5.9.1/mkspecs /usr/local/mkspecs && ln -s /usr/local/Cellar/qt/5.9.1/plugins /usr/local/plugins
+```
+
+If Qt is installed from brew package Qt libraries have rpaths which are not correctly processed by `macdeployqt` tool. To overcome `macdeploy` issues during Mac OS .app bundle creation, it's possible to run `macdeployqtfix.py` tool after `macdeployqt` finishes the work:
+
+```
+sh ('macdeployqt ' + packageFolder + '/StatusIm.app -always-overwrite -verbose=1 -qmldir="' + scriptPath + '/node_modules/react-native/ReactQt/application/src/" -qmldir="' + scriptPath + '/node_modules/react-native/ReactQt/runtime/src/qml/"')
+sh ('python /Users/administrator/macdeployqtfix/macdeployqtfix/macdeployqtfix.py ' + packageFolder + '/StatusIm.app/Contents/MacOs/StatusIm /usr/local/Cellar/qt/5.9.1')
+
+```
+
+## General setup
+
+### react-native-cli
+
+Modified react-native-cli can be installed globally on Jenkins machine from some location.
+
+```
+cd ~/
+git clone https://github.com/status-im/react-native-desktop.git
+cd react-native-desktop/react-native-cli
+npm install -g
+```

--- a/docs/build_desktop_troubleshooting.md
+++ b/docs/build_desktop_troubleshooting.md
@@ -1,0 +1,145 @@
+---
+id: build_desktop_troubleshooting
+title: Desktop Troubleshooting
+---
+
+## Initial setup issues
+
+### `npm install` hangs
+Downgrade to version 5.5.1: `npm install -g npm@5.5.1`.
+
+### `re-natal` missing
+Create a link:
+`ln -sf node_modules/re-natal/index.js re-natal`
+
+
+### `react-native run desktop` complaining about missing `qmldir`:
+```Command failed: ./build.sh -e "node_modules/react-native-i18n/desktop;node_modules/react-native-config/desktop;node_modules/react-native-fs/desktop;node_modules/react-native-http-bridge/desktop;node_modules/react-native-webview-bridge/desktop;modules/react-native-status/desktop"
+Error copying directory from "/path-to-status-react/node_modules/react-native/ReactQt/runtime/src/qmldir" to "/path-to-status-react/desktop/lib/React".
+make[2]: *** [lib/CMakeFiles/copy-qmldir] Error 1
+make[1]: *** [lib/CMakeFiles/copy-qmldir.dir/all] Error 2
+make: *** [all] Error 2
+```
+Can be solved by re-running `npm install react-native` which put the `ReactQt/runtime/src/qmldir` file back.
+
+### Missing web3 package issue
+
+After last upgrade of react-native-desktop to the v.0.53.3 of original react-native appeared some incompatibility between `react-native` and `web3` packages on npm install. Initially it installed usually fine, but after `react-native desktop` command execution `web3` package is get removed from `node_modules`. Manual install of web3 by `npm install web3` installs `web3` package, but removes `react-native` package. Workaround or solution?
+
+### Go problem
+```
+panic: runloop has just unexpectedly stopped
+
+goroutine 50 [running]:
+github.com/status-im/status-go/vendor/github.com/rjeczalik/notify.init.0.func1()
+        /path-to-status-react/desktop/modules/react-native-status/desktop/StatusGo/src/github.com/status-im/status-go/vendor/github.com/rjeczalik/notify/watcher_fsevents_cgo.go:69 +0x79
+created by github.com/status-im/status-go/vendor/github.com/rjeczalik/notify.init.0
+        /path-to-status-react/desktop/modules/react-native-status/desktop/StatusGo/src/github.com/status-im/status-go/vendor/github.com/rjeczalik/notify/watcher_fsevents_cgo.go:65 +0x4e
+events.js:183
+      throw er; // Unhandled 'error' event
+```
+Related to https://github.com/rjeczalik/notify/issues/139. Solution: re-run.
+
+## App issues
+
+### Node server crashing
+`node ./ubuntu_server.js` log:
+```
+DEBUG [status-im.utils.handlers:36] - Handling re-frame event:  :signal-event {"type":"node.crashed","event":{"error":"node is already running"}}
+DEBUG [status-im.ui.screens.events:350] - :event-str {"type":"node.crashed","event":{"error":"node is already running"}}
+DEBUG [status-im.utils.instabug:8] - Signal event: {"type":"node.crashed","event":{"error":"node is already running"}}
+DEBUG [status-im.ui.screens.events:362] - Event  node.crashed  not handled
+```
+Solution: prevent starting Node when there is an instance already running.
+
+### Reload JS - blank screen
+Console log for `react-native run-desktop` shows error 533.
+Solution: reload again. Still, might hang at `Signing you in...` step (due to node attempted to be restarted). Re-run Figwheel and `react-native run-desktop`
+
+### ReactButton.qml non-existent property "elide" error upon startup
+```
+qrc:/qml/ReactButton.qml:33: Error: Cannot assign to non-existent property "elide"
+"Component for qrc:/qml/ReactWebView.qml is not loaded"
+QQmlComponent: Component is not ready
+"Unable to construct item from component qrc:/qml/ReactWebView.qml"
+"Can't create QML item for componenet qrc:/qml/ReactWebView.qml"
+"RCTWebViewView" has no view for inspecting!
+```
+Reload JS does not help, restarting Figwheel/react-native might not as well. Restarting Metro bundler solved it for me.
+
+### After login when several contacts are available: realm errors
+1. `attempting to create an object of type 'chat'...`
+2. `attempting to create an object of type 'transport'...`
+3. Error text containing only the public key.
+The realm stack trace follows.
+
+### Error: spawn gnome-terminal ENOENT
+In node server log:
+```
+ignoring exception: Error: read ECONNRESET
+```
+In react-native log:
+```
+./run-app.sh: line 72: 56660 Segmentation fault: 11  /path-to-status-react/desktop/bin/StatusIm $args
+events.js:183
+      throw er; // Unhandled 'error' event
+      ^
+
+Error: spawn gnome-terminal ENOENT
+    at _errnoException (util.js:992:11)
+    at Process.ChildProcess._handle.onexit (internal/child_process.js:190:19)
+    at onErrorNT (internal/child_process.js:372:16)
+    at _combinedTickCallback (internal/process/next_tick.js:138:11)
+    at process._tickCallback (internal/process/next_tick.js:180:9)
+```
+or
+```
+StatusIm(7924,0x70000c1cd000) malloc: *** error for object 0x7f8b1539bd10: incorrect checksum for freed object - object was probably modified after being freed.
+*** set a breakpoint in malloc_error_break to debug
+./run-app.sh: line 72:  7924 Abort trap: 6           /path-to-status-react/desktop/bin/StatusIm $args
+events.js:183
+      throw er; // Unhandled 'error' event
+      ^
+
+Error: spawn gnome-terminal ENOENT
+    at _errnoException (util.js:992:11)
+    at Process.ChildProcess._handle.onexit (internal/child_process.js:190:19)
+    at onErrorNT (internal/child_process.js:372:16)
+    at _combinedTickCallback (internal/process/next_tick.js:138:11)
+    at process._tickCallback (internal/process/next_tick.js:180:9)
+```
+
+### statusgo error during `react-native run-desktop`
+
+```
+Command failed: build(.)sh -e "node_modules/react-native-i18n/desktop;node_modules/react-native-config/desktop;node_modules/react-native-fs/desktop;node_modules/react-native-http-bridge/desktop;node_modules/react-native-webview-bridge/desktop;modules/react-native-status/desktop"
+# github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/crypto/bn256
+../vendor/github.com/ethereum/go-ethereum/crypto/bn256/bn256_fast.go:26: syntax error: unexpected = in type declaration
+../vendor/github.com/ethereum/go-ethereum/crypto/bn256/bn256_fast.go:30: syntax error: unexpected = in type declaration
+# github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/crypto/bn256
+vendor/github.com/ethereum/go-ethereum/crypto/bn256/bn256_fast.go:26: syntax error: unexpected = in type declaration
+vendor/github.com/ethereum/go-ethereum/crypto/bn256/bn256_fast.go:30: syntax error: unexpected = in type declaration
+make[3]: *** [statusgo-library] Error 2
+make[2]: *** [modules/react-native-status/desktop/StatusGo/src/github.com/status-im/src/StatusGo_ep-stamp/StatusGo_ep-configure] Error 2
+make[1]: *** [modules/react-native-status/desktop/CMakeFiles/StatusGo_ep(.)dir/all] Error 2
+make: *** [all] Error 2
+```
+
+### inotify errors
+
+upon running `npm start` on linux, watchman may indicate: "The user limit on the total number of inotify watches was reached"
+
+This can be fixed by running the below command. Note, changes will only be as valid as the current terminal session.
+
+```
+echo 999999 | sudo tee -a /proc/sys/fs/inotify/max_user_watches && echo 999999 | sudo tee -a
+/proc/sys/fs/inotify/max_queued_events && echo 999999 | sudo tee -a /proc/sys/fs/inotify/max_user_instances &&
+watchman shutdown-server && sudo sysctl -p
+```
+
+### metro bundler caching issue
+
+Time to time metro bundler for some reasons doesn't recognize changes in JavaScript sources and returns old version of the files on react-native app request. Cleaning of cache should help to solve the issue (usually running `react-native start --reset-cache` to start the bundler should work) .
+
+On Linux metro bundler saves cache to the following directories (can be removed manually):
+/tmp/metro-cache-*

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,7 +1,8 @@
 {
   "docs": {
     "Introduction": ["introduction", "faqs"],
-    "Build Status": ["build_status", "contributor_guide"],
+    "Build Status Mobile": ["build_status", "contributor_guide"],
+    "Build Status Desktop": ["build_desktop", "build_desktop_troubleshooting", "build_desktop_google_breakpad", "build_desktop_jenkins"],
     "Build DApps": ["embark", "intro_dapps", "status_optimized", "status_web_api", "extensions_tutorial_chat_command"]
   },
   "testing": {


### PR DESCRIPTION
Moving https://github.com/status-im/react-native-desktop/wiki/Dev-env-setup to docs.status.im

This is first pass and we will update these to be much nicer. 