### PR TITLE
Updated JS API

### DIFF
--- a/source/developer_tools/status_web_api.md
+++ b/source/developer_tools/status_web_api.md
@@ -7,28 +7,23 @@ title: Status JavaScript API
 
 On top of regular `web3` access, Status offers a set of API available to DApps developers. This API follows the [EIP1102](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1102.md) standard that will soon be used for web3 injection.
 
-When [Status is the host browser](https://docs.status.im/docs/status_optimized.html#detecting-status), DApp developers can request access to Status-specific data using the JavaScript API. 
+When [Status is the host browser](https://docs.status.im/docs/status_optimized.html#detecting-status), DApp developers can request access to Status-specific data using the JavaScript API available at `window.web3.currentProvider.status`. 
 
-### How to use it
+#### JavaScript API methods
 
-To make requests to the Status JavaScript API, send a message using the `window.postMessage` API. This message must be sent with a payload object containing a type property with a value of `'STATUS_API_REQUEST'` and a `permissions` property for the requested permissions, e.g. `“CONTACT_CODE”`.
-
-Status will notify the DApp of successful API exposure by dispatching an event on `window` object. This event will contain a `detail` object with allowed `permissions` and `data` properties.
-
-
-#### JavaScript API properties
-
-*  `"CONTACT_CODE"` provides access to a user's Whisper ID, which can be used to initiate chats or add a contact.
+*  `getContactCode` provides access to a user's Whisper ID, which can be used to initiate chats or add a contact.
 
 #### Example implementation
 
 ```JavaScript
-window.addEventListener('statusapi', function (event) {
-    console.log(event.detail.permissions) //=> ["CONTACT_CODE"] if allowed 
-    console.log(event.detail.data["CONTACT_CODE"]) //=> "0x0012300..123" if allowed
-});
-// request status API
-window.postMessage({ type: 'STATUS_API_REQUEST', permissions: ["CONTACT_CODE"] }, '*');
+window.web3.currentProvider.status
+ .getContactCode()
+ .then(data => {
+   console.log('Contact code:', data)
+ })
+ .catch(err => {
+   console.log('Error:', err)
+ })
 ```
 
 ## Others API


### PR DESCRIPTION
According to the latest web3 opt-in EIP status injects read-only ethereum provider, we can expand this provider with status api, so there is no need in messages anymore


Before
```JavaScript
window.addEventListener('statusapi', function (event) {
    console.log(event.detail.permissions) //=> ["CONTACT_CODE"] if allowed 
    console.log(event.detail.data["CONTACT_CODE"]) //=> "0x0012300..123" if allowed
});
// request status API
window.postMessage({ type: 'STATUS_API_REQUEST', permissions: ["CONTACT_CODE"] }, '*');
```

After
```JavaScript
ethereum.status.getContactCode().then(data => {console.log('Contact code:', data)});
```
